### PR TITLE
Release/0.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 node_modules
 *.log
+.env
+local

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install --save @strawbees/s3-publisher
 
 Make sure `S3_KEY` and `S3_SECRET` (AWS credentials) are set amongst your environment variables. You can provide a environment config file `.env`.
 
-Optionally you can set `BUCKET` and this will override the option `--bucket` if given.
+Optionally you can set `S3_BUCKET` and `S3_REGION` and this will override the option `--bucket` and `--region` if given.
 
 An example of `.env` file would be:
 
@@ -22,6 +22,7 @@ An example of `.env` file would be:
 S3_KEY="123"
 S3_SECRET="iwatchpeppapig"
 S3_BUCKET="my-bucket-on-s3"
+S3_REGION="us-west-1"
 ```
 
 ### Client API
@@ -35,6 +36,7 @@ Options:
   -b, --bucket <bucket>     S3 Bucket name. Required `BUCKET` in your environment variables.
   -s, --source <path>       Local folder path. Required.
   -d, --destination <path>  Path on S3 Bucket (Prefix).
+  -r, --region <region>     S3 Bucket region.
   --sync                    Sync local folder with bucket. This will remove files on the S3 Bucket that are not on `--source`.
   -v, --version             output the version number
   -h, --help                output usage information
@@ -54,4 +56,4 @@ Assuming your project has `s3-publisher` installed, it should be available to `n
 }
 ```
 
-If you don't want to commit the name of your bucket, set `BUCKET` environment variable with the name of your bucket and just skip the `--bucket` option.
+If you don't want to commit the name of your bucket, set `S3_BUCKET` environment variable with the name of your bucket and just skip the `--bucket` option. The same applies to the `--region` option and the `S3_REGION` environment variable.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,57 @@
 # Strawbees S3 Publisher
 
 Command line tool for publishing files to Amazon S3 Buckets. It's a thin API layer on top of [@monolambda/s3](https://www.npmjs.com/package/@monolambda/s3) npm package.
+
+## Installing
+
+```
+npm install --save @strawbees/s3-publisher
+```
+
+## Usage
+
+### Environment variables
+
+Make sure `S3_KEY` and `S3_SECRET` (AWS credentials) are set amongst your environment variables. You can provide a environment config file `.env`.
+
+Optionally you can set `BUCKET` and this will override the option `--bucket` if given.
+
+An example of `.env` file would be:
+
+```
+S3_KEY="123"
+S3_SECRET="iwatchpeppapig"
+S3_BUCKET="my-bucket-on-s3"
+```
+
+### Client API
+
+```
+Usage: s3-publisher [options]
+
+Command line tool for publishing to Amazon S3.
+
+Options:
+  -b, --bucket <bucket>     S3 Bucket name. Required `BUCKET` in your environment variables.
+  -s, --source <path>       Local folder path. Required.
+  -d, --destination <path>  Path on S3 Bucket (Prefix).
+  --sync                    Sync local folder with bucket. This will remove files on the S3 Bucket that are not on `--source`.
+  -v, --version             output the version number
+  -h, --help                output usage information
+```
+
+## Example
+
+Assuming your project has `s3-publisher` installed, it should be available to `npm` as a "binary". That means you can call it from `package.json` scripts:
+
+```json
+{
+	"scripts": {
+		"build": "build --output ./dist",
+		"publish": "s3-publisher -b bucket-name -s ./dist --sync",
+		"ci": "npm run build && npm run publish"
+	}
+}
+```
+
+If you don't want to commit the name of your bucket, set `BUCKET` environment variable with the name of your bucket and just skip the `--bucket` option.

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,11 @@
             "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
             "integrity": "sha1-zFRJaF37hesRyYKKzHy4erW7/MA="
         },
+        "dotenv": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
+            "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g=="
+        },
         "events": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "s3-publisher",
+    "name": "@strawbees/s3-publisher",
     "version": "0.1.0",
     "lockfileVersion": 1,
     "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "s3-publisher",
+    "name": "@strawbees/s3-publisher",
     "version": "0.1.0",
     "description": "Command line tool for publishing to Amazon S3",
     "main": "s3-publisher.js",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "license": "MIT",
     "dependencies": {
         "@monolambda/s3": "^1.0.2",
-        "commander": "^2.19.0"
+        "commander": "^2.19.0",
+        "dotenv": "^7.0.0"
     }
 }

--- a/s3-publisher.js
+++ b/s3-publisher.js
@@ -10,6 +10,7 @@ program
 	.option('-b, --bucket <bucket>', 'S3 Bucket name. Required `BUCKET` in your environment variables.')
 	.option('-s, --source <path>', 'Local folder path. Required.')
 	.option('-d, --destination <path>', 'Path on S3 Bucket (Prefix).')
+	.option('-r, --region <region>', 'S3 Bucket region.')
 	.option('--sync', 'Sync local folder with bucket. This will remove files on the S3 Bucket that are not on `--source`.')
 	.description(`Command line tool for publishing to Amazon S3.`)
 	.version(pkg.version, '-v, --version')
@@ -19,6 +20,7 @@ program.parse(process.argv)
 const SOURCE = program.source
 const DESTINATION = program.destination
 const BUCKET = process.env.S3_BUCKET ? process.env.S3_BUCKET : program.bucket
+const REGION = process.env.S3_REGION ? process.env.S3_REGION : program.region
 const SYNC = program.sync || false
 const ACCESS_KEY = process.env.S3_KEY
 const SECRET = process.env.S3_SECRET
@@ -34,7 +36,7 @@ if (!SOURCE) {
 	return
 }
 
-const client = getClient(ACCESS_KEY, SECRET)
+const client = getClient(ACCESS_KEY, SECRET, REGION)
 const uploader = client.uploadDir({
 	localDir: SOURCE,
 	deleteRemoved: SYNC,

--- a/s3-publisher.js
+++ b/s3-publisher.js
@@ -1,7 +1,51 @@
 #!/usr/bin/env node
+require('dotenv').config()
+const s3 = require('@monolambda/s3')
 const program = require('commander')
 const pkg = require('./package.json')
+const getClient = require('./utils/get-client.js')
+const getCacheControl = require('./utils/get-cache-control.js')
 
 program
+	.option('-b, --bucket <bucket>', 'S3 Bucket name. Required `BUCKET` in your environment variables.')
+	.option('-s, --source <path>', 'Local folder path. Required.')
+	.option('-d, --destination <path>', 'Path on S3 Bucket (Prefix).')
+	.option('--sync', 'Sync local folder with bucket. This will remove files on the S3 Bucket that are not on `--source`.')
 	.description(`Command line tool for publishing to Amazon S3.`)
 	.version(pkg.version, '-v, --version')
+
+program.parse(process.argv)
+
+const SOURCE = program.source
+const DESTINATION = program.destination
+const BUCKET = process.env.S3_BUCKET ? process.env.S3_BUCKET : program.bucket
+const SYNC = program.sync || false
+const ACCESS_KEY = process.env.S3_KEY
+const SECRET = process.env.S3_SECRET
+
+if (!BUCKET) {
+	console.log('You must specify `--bucket`.\n')
+	program.help()
+	return
+}
+if (!SOURCE) {
+	console.log('You must specify `--source`.\n')
+	program.help()
+	return
+}
+
+const client = getClient(ACCESS_KEY, SECRET)
+const uploader = client.uploadDir({
+	localDir: SOURCE,
+	deleteRemoved: SYNC,
+	s3Params: {
+		Bucket: BUCKET,
+		Prefix: DESTINATION
+	},
+	getS3Params: (localFile, stat, callback) => {
+		let CacheControl = getCacheControl(localFile, SOURCE)
+		callback(null, { CacheControl })
+	}
+})
+uploader.on('error', (err) => console.log('error', err))
+uploader.on('end', () => console.log('Finished.'))

--- a/utils/get-cache-control.js
+++ b/utils/get-cache-control.js
@@ -1,0 +1,25 @@
+const path = require('path')
+
+module.exports = (localFile, source) => {
+	let CacheControl
+	if (
+		path.basename(localFile) === 'service-worker.js'
+		|| localFile.indexOf( path.join(source, 'workbox-') !== -1 )
+	) {
+		// never cache the service workers
+		CacheControl = 'no-cache'
+	} else {
+		switch (path.extname(localFile)) {
+			case '.html':
+			case '.json':
+				// cache for 2 minutes
+				CacheControl = 'max-age=120, public, no-transform'
+				break
+			default:
+				// cache "forever"
+				CacheControl = 'max-age=604800, public, no-transform'
+		}
+	}
+	console.log(`Uploading -> ${localFile}`)
+	return CacheControl
+}

--- a/utils/get-client.js
+++ b/utils/get-client.js
@@ -1,0 +1,17 @@
+const s3 = require('@monolambda/s3');
+
+module.exports = (key, secret) => {
+	return s3.createClient({
+		maxAsync: 20,
+		s3RetryCount: 3,
+		s3RetryDelay: 1000,
+		multipartUploadThreshold: 20971520,
+		multipartUploadSize: 15728640,
+		s3Options: {
+			accessKeyId: key,
+			secretAccessKey: secret,
+			// any other options are passed to new AWS.S3()
+			// See: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#constructor-property
+		}
+	})
+}

--- a/utils/get-client.js
+++ b/utils/get-client.js
@@ -1,6 +1,6 @@
 const s3 = require('@monolambda/s3');
 
-module.exports = (key, secret) => {
+module.exports = (key, secret, region) => {
 	return s3.createClient({
 		maxAsync: 20,
 		s3RetryCount: 3,
@@ -10,6 +10,7 @@ module.exports = (key, secret) => {
 		s3Options: {
 			accessKeyId: key,
 			secretAccessKey: secret,
+			region: region
 			// any other options are passed to new AWS.S3()
 			// See: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#constructor-property
 		}


### PR DESCRIPTION
This release implements the most basic API possible for a `s3-publisher` client that fulfill the following requirements:

- Both developer and CI should be able to use it.
- Should be able to "sync" files by removing the files on bucket that are not on local files.
- Sync an arbitrary folder from local files to arbitrary folder on s3 bucket.
- Get AWS credentials from environment variables `S3_KEY` and `S3_SECRET`.
- Override `--bucket` option with `BUCKET` environment variable.
